### PR TITLE
Fast graphviz

### DIFF
--- a/makegen_config/server_default_template.json
+++ b/makegen_config/server_default_template.json
@@ -17,6 +17,12 @@
 	},
 
 	"graphviz-parameters" : {
+		"dot" : true,
+		"pdf" : true,
+		"svg" : true,
+
+		"assign-position" : true,
+
 		"graph-attributes" : [
 			["nodesep" , "0.1"],
 	        ["ranksep" , "1"],

--- a/makegen_config/template.json
+++ b/makegen_config/template.json
@@ -22,6 +22,8 @@
 		"pdf" : true,
 		"svg" : true,
 
+		"assign-position" : true,
+
 		"graph-attributes" : [
 			["nodesep" , "0.1"],
 	        ["ranksep" , "1"],

--- a/makegen_config/test.json
+++ b/makegen_config/test.json
@@ -20,21 +20,23 @@
 
 		"dot" : true,
 		"pdf" : true,
-		
+
+		"assign-position" : true,
+
 		"graph-attributes" : [
 			["nodesep" , "0.1"],
 	        ["ranksep" , "1"],
 	        ["ratio"   , "fill"],
 	        ["size"    , "6"]
 		],
-		
+
 		"node-attributes" : [
 			["style"     , "filled"],
 	        ["shape"     , "point"],
 	        ["width"     , "1"],
 	        ["height"    , "1"]
 		],
-		
+
 		"edge-attributes" : [
 			["penwidth", "1"]
 		]

--- a/server/flask_main.py
+++ b/server/flask_main.py
@@ -39,6 +39,7 @@ def run_server_publicly():
 
 def get_user_args(form_data):
     #print(form_data)
+    print(form_data.get('should_run_fast'))
     return {
         "M": int(form_data.get('Mval')),
         "N": int(form_data.get('Nval')),
@@ -47,7 +48,8 @@ def get_user_args(form_data):
         "C": float(form_data.get('Cval')),
         #"P": int(request.form.get('RedToBlueSurvival')),
         "init-distribution": [int(form_data.get('RedStart'))/(int(request.form.get('BlueStart'))+int(request.form.get('RedStart')))],
-        "V": [int(form_data.get('RedSurvival')),int(form_data.get('BlueSurvival'))]
+        "V": [int(form_data.get('RedSurvival')),int(form_data.get('BlueSurvival'))],
+        'assign-position': form_data.get('should_run_fast') == "true"
     }
 
 def verify_user_args(user_args):
@@ -94,6 +96,7 @@ def process_template(user_args):
 
     graphviz_parameters = data["graphviz-parameters"]
     graphviz_parameters["cs-to-color"] = lambda cs: "#FF0000" if cs[0] else "#0000FF"
+    graphviz_parameters["assign-position"] = user_args['assign-position']
 
     # Genealogy
     genea = G.Genealogy(genealogy_parameters)

--- a/server/static/html/graph.html
+++ b/server/static/html/graph.html
@@ -27,6 +27,7 @@ p.err_style{
         Age adjustment: <input type="number" id="Aval" step=0.2 value=0><br>
         Citation adjustment: <input type="number" id="Cval" step=0.2 value=0><br>
         <div id="Cvalerr" hidden><p class="err_style">Input error: Cannot be negative</p><br></div>
+        Enble fast graph rendering: <input id="fast_checkbox" type="checkbox">
     </div>
     <button id="submitbutton">Generate Plot</button>
     <div id="svg_item"></div>

--- a/server/static/js/graph.js
+++ b/server/static/js/graph.js
@@ -53,6 +53,7 @@ function load_svg(){
         'BlueStart': document.getElementById('BlueStart').value,
         'Aval': document.getElementById('Aval').value,
         'Cval': document.getElementById('Cval').value,
+        'should_run_fast': document.getElementById('fast_checkbox').checked,
     }
     $.ajax({
         type: 'POST',


### PR DESCRIPTION
Gives user an option to use a different rendering scheme that can render thousands of points. 

This option works by manually setting the position of each node using the graphviz `pos` option. 

the dot file ends up looking something like:

```
"0:0" [ label="2" color="#0000FF" pos="0,0!"];
"0:0" -- "1:2" [ color="#0000FF"];
"0:0" -- "1:6" [ color="#0000FF"];
"0:0" -- "2:2" [ color="#0000FF"];
"0:1" [ label="2" color="#0000FF" pos="1,0!"];
"0:1" -- "1:8" [ color="#0000FF"];
"0:1" -- "6:5" [ color="#0000FF"];
"0:2" [ label="2" color="#0000FF" pos="2,0!"];
```

When position is enabled, ranking is disabled, so no ranking information appears in the dot file. 